### PR TITLE
Remove randomness from uuid generation

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,10 +8,13 @@ export namespace Utils {
     return true;
   }
 
+  let uuidCounter = 1;
+
   export function uuid() {
-    return `${new Date().getMilliseconds()}:${Utils.getRandomInt(
-      9999999999999,
-    )}:${Utils.getRandomInt(9999999999999)}`;
+    if (uuidCounter === Number.MAX_SAFE_INTEGER) {
+      uuidCounter = 1;
+    }
+    return `${new Date().getMilliseconds()}:${uuidCounter++}`;
   }
 
   export function getRandomInt(max) {


### PR DESCRIPTION
Even though it would be **extremely hard** to generate the same *uuid* twice, this PR removes that possibility. 

Please feel free to reject it.

----

*This is a solution for a dystopian future where an identical uuid is generated for two methods, such as 'enableWorldPeace' and 'dropTheBomb'.*